### PR TITLE
perf: Consumes a lot cpu when is hidden

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -170,7 +170,7 @@ impl<'a> App for MainApp<'a> {
                             return;
                         }
                     };
-                    if let Some(input_event) = actions.get(input_action) {
+                    if let Some(input_event) = actions.get(&input_action) {
                         if input_event
                             .modifier
                             .zip(modifiers)
@@ -205,7 +205,7 @@ impl<'a> App for MainApp<'a> {
                         return;
                     };
 
-                    if let Some(input_event) = actions.get(input_action) {
+                    if let Some(input_event) = actions.get(&input_action) {
                         if input_event
                             .modifier
                             .zip(modifiers)
@@ -232,7 +232,7 @@ impl<'a> App for MainApp<'a> {
                 } else {
                     InputAction::ScrollDown
                 };
-                if let Some(input_event) = actions.get(input_action) {
+                if let Some(input_event) = actions.get(&input_action) {
                     if input_event
                         .modifier
                         .zip(modifiers)

--- a/src/window.rs
+++ b/src/window.rs
@@ -244,9 +244,7 @@ impl<T: AppTy> ApplicationHandler for Window<T> {
                 render.event(e);
             }
             WindowEvent::RedrawRequested => {
-                if can_show {
-                    window.draw(self.context.get_data());
-                }
+                window.draw(self.context.get_data());
                 window.window.request_redraw();
             }
             e => {


### PR DESCRIPTION
In many renderers is very common that if you don't update the buffer it gets a lot of CPU or RAM.
